### PR TITLE
Update to AGENTS.md + application shell 

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -32,10 +32,9 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       # `pnpm build` runs prebuild (docs:gen + registry:build) then the static
-      # export. PAGES_BASE_PATH makes assets/links resolve under /design-system.
+      # export. The site is served at the custom domain design.edgecom.ai (root
+      # path), so no base path; public/CNAME pins the domain in the artifact.
       - run: pnpm build
-        env:
-          PAGES_BASE_PATH: /design-system
 
       - uses: actions/configure-pages@v5
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 .env.example
+.env.local
 
 # vercel
 .vercel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,42 @@ Accessibility bar (mirror the site's **Accessibility** doc):
 - The type scale is in `rem` — don't pin sizes to px.
 - Focus rings use the `--ring` token (it's a focus-outline color, not a fill).
 
+## UI guardrails — building with the design system
+
+These apply whenever you build UI with these components (in this repo or a consuming app). The registry install address is configured per app — see [REGISTRY.md](REGISTRY.md); the commands below are generic.
+
+### Import from the registry — don't recreate
+
+- **Use the existing component.** Never hand-write your own version of something the design system already provides (button, dialog, input, table, …). Reuse over recreation.
+- **Discover first, then install.** Check what exists (`shadcn list` / `shadcn view` against the registry) — the installable set is the **64 UI primitives + `theme` + `use-mobile`** — then `shadcn add` it. Don't copy/paste or reimplement a primitive. The `theme` (OKLCH tokens) rides along on the first install.
+- **Compose, don't reinvent.** Build higher-level patterns (blocks, page sections) from the installed primitives — blocks are **not** registry items.
+- **No suitable component → STOP and ask (mandatory).** Do not silently hand-roll a bespoke component. Prompt the user with three options and proceed only after they choose: (a) adapt the closest existing registry component, (b) request it be added to the design system, or (c) get explicit approval for a documented, clearly-marked local one-off.
+- **In this repo** you author primitives rather than install them — the analog rule is: reuse or extend an existing [`src/components/ui/*`](src/components/ui) primitive (or a `shadcn-studio` demo pattern) before adding a new one; don't duplicate.
+
+### Responsiveness & scaling
+
+- **Mobile-first.** Build for small screens first and layer up with Tailwind breakpoints (`sm`/`md`/`lg`/`xl`/`2xl`); no desktop-only layouts.
+- **Relative units, not fixed px.** Use the `rem`-based type scale (`text-caption`…`text-display`) and the spacing / `radius-*` scales; don't pin font sizes or container dimensions to px.
+- **Fluid layout.** Flex/grid with `min-w-0`, `max-w-*`, and wrapping so content reflows — it must never clip or force horizontal page scroll. Wide content (tables, code) scrolls inside its own `overflow-x-auto` container.
+- **Reuse breakpoint logic.** Use the `use-mobile` hook (`useIsMobile`, 768px) for conditional rendering instead of ad-hoc `matchMedia`.
+- **Touch targets & media.** Keep adequate hit areas on touch; `max-w-full` on images/media so nothing overflows.
+
+### Dark mode & theming
+
+- **Every color is a semantic token** with both light (`:root`) and dark (`.dark`) values in [`globals.css`](src/app/globals.css) — never hardcode hex or one-off colors; they won't adapt to dark.
+- **Right token for the job.** Surfaces (`background`/`card`/`popover`/`elevated`) with their `-foreground` for text; `-emphasis` for a status color rendered as text or a thin icon; `-subtle` (+ `-subtle-foreground`) for tinted surfaces. Don't use a base fill color as a text color.
+- **Contrast in both themes.** Hold WCAG AA (4.5:1 text, 3:1 large text / UI) and AAA where the palette allows — light and dark alike. Verify new or tuned colors in both (the live **Semantic colors** page has a contrast meter).
+- **Mechanics.** Dark mode is the `.dark` class on the `<html>` root; portaled content (dropdown, popover, tooltip, toast) inherits it — don't build light-only components. Adding or adjusting a color means editing `globals.css` (both `:root` **and** `.dark`), not the call site.
+- **Always test both light and dark** before shipping anything visible.
+
+### Other guardrails
+
+- **Accessibility.** Rely on Base UI primitives for interactive widgets — don't reimplement them (you lose keyboard/ARIA support). Keep a visible focus ring via `--ring` (never `outline: none` with no replacement), label form fields, and give images alt text.
+- **Loading / empty / error states.** Use the provided `skeleton`, `spinner`, and `empty` components; don't ship raw loading gaps or unhandled empty/error states.
+- **Use the scales, not magic numbers.** Prefer the spacing, `radius-*`, and type scales over arbitrary px, Tailwind `[...]` arbitrary values, or inline `style`.
+- **Compose, don't fork.** Compose primitives and their `data-slot` hooks; don't copy a primitive to tweak it or reach into its internals fragilely.
+- **Motion.** Respect `prefers-reduced-motion`; use the available `motion` / `tw-animate-css` sparingly.
+
 ## Adding or changing a component
 
 1. Primitive → `src/components/ui/<name>.tsx` (follow the house style above).
@@ -103,12 +139,12 @@ These are **docs demos, not registry items** — vendor-imported from shadcn-stu
 
 ## Docs-site architecture (static export)
 
-The site is a **static export** (`output: "export"` in [`next.config.ts`](next.config.ts)) deployed to GitHub Pages via [`.github/workflows/deploy-pages.yml`](.github/workflows/deploy-pages.yml) on push to `main`.
+The site is a **static export** (`output: "export"` in [`next.config.ts`](next.config.ts)), built and published on push to `main` (see [`.github/workflows/deploy-pages.yml`](.github/workflows/deploy-pages.yml)) and served at its custom domain **[design.edgecom.ai](https://design.edgecom.ai)** (root path).
 
 - The chrome (sidebar + header + content) renders **once** from [`src/app/(docs)/layout.tsx`](src/app/(docs)/layout.tsx) — a route-group layout — so the sidebar persists across navigations instead of remounting.
 - [`src/app/(docs)/[group]/[slug]/page.tsx`](src/app/(docs)/[group]/[slug]/page.tsx) returns `null` but **must keep `generateStaticParams()`** (from `src/docs/generated/routes.ts`) — static export requires it to prerender one HTML file per section.
 - **Don't move `DocsShell` back into the page** (it remounts → the sidebar scroll jumps to top on every click) and **don't drop `generateStaticParams`** (the static build fails).
-- `basePath` / `NEXT_PUBLIC_BASE_PATH` prefix asset and runtime-fetch URLs for the `/design-system` GitHub Pages path; local `pnpm dev` stays at `/`.
+- `basePath` / `NEXT_PUBLIC_BASE_PATH` (from `PAGES_BASE_PATH`) prefix asset and runtime-fetch URLs when the site is served under a sub-path (e.g. the legacy `…github.io/design-system` path); the production domain and local `pnpm dev` both serve at `/`.
 
 ## Verifying changes
 
@@ -119,6 +155,9 @@ There is **no test framework** in this repo. The quality gates are:
 
 ## Do-nots
 
+- Don't hand-write a component the registry already provides — import it; if none fits, stop and ask.
+- Don't hardcode colors or ship light-only UI — every color is a light+dark token; test both.
+- Don't pin sizes to px — use the rem type / spacing / radius scales.
 - Don't hardcode hex — use semantic tokens.
 - Don't hand-edit generated files (see the table above).
 - Don't `--overwrite` custom primitives when pulling shadcn-studio components.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,9 @@
 import type { NextConfig } from "next";
 
-// The docs site is deployed to GitHub Pages as a fully static export
-// (https://edgecom-ai.github.io/design-system/). The base path is injected at
-// build time via PAGES_BASE_PATH so local `pnpm dev` and any root-hosted build
-// stay at "/". The CI workflow sets PAGES_BASE_PATH=/design-system.
+// The docs site is a fully static export deployed to GitHub Pages and served at
+// the custom domain https://design.edgecom.ai (root path) — no base path by
+// default. PAGES_BASE_PATH can still inject one for a sub-path deployment (e.g.
+// a project-pages URL); local `pnpm dev` stays at "/".
 const basePath = process.env.PAGES_BASE_PATH ?? "";
 
 const nextConfig: NextConfig = {

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+design.edgecom.ai

--- a/src/app/sections.tsx
+++ b/src/app/sections.tsx
@@ -65,6 +65,7 @@ import NativeSelectPlaceholderDemo from "@/components/shadcn-studio/select/selec
 import NativeSelectRequiredDemo from "@/components/shadcn-studio/select/select-06";
 import SelectWithOptionsGroupsDemo from "@/components/shadcn-studio/select/select-22";
 import MultipleSelectWithPlaceholderDemo from "@/components/shadcn-studio/select/select-33";
+import MultiSelectPreselectedDemo from "@/components/shadcn-studio/select/select-32";
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 import { Label } from "@/components/ui/label";
 import { Logo } from "@/components/ui/logo";
@@ -2422,6 +2423,13 @@ export const sections: Section[] = [
         description: "A multi-select that accepts several values at once.",
         preview: <MultipleSelectWithPlaceholderDemo />,
         source: ss("select/select-33"),
+      },
+      {
+        id: "select-multiple-preselected",
+        name: "Multiple with preset values",
+        description: "A multi-select pre-populated with selected values and inline tags.",
+        preview: <MultiSelectPreselectedDemo />,
+        source: ss("select/select-32"),
       },
     ],
   },

--- a/src/components/demo/application-shell-demo.tsx
+++ b/src/components/demo/application-shell-demo.tsx
@@ -1,19 +1,6 @@
 "use client"
 
-import { Logo } from "@/components/ui/logo"
-import { Button } from "@/components/ui/button"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Badge } from "@/components/ui/badge"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupInput,
-} from "@/components/ui/input-group"
-import ProfileDropdown from "@/components/shadcn-studio/blocks/dropdown-profile"
-import NotificationDropdown from "@/components/shadcn-studio/blocks/dropdown-notification"
-import LanguageDropdown from "@/components/shadcn-studio/blocks/dropdown-language"
-import ActivityDialog from "@/components/shadcn-studio/blocks/dialog-activity"
+import * as React from "react"
 import {
   LayoutDashboard,
   Gauge,
@@ -26,7 +13,36 @@ import {
   Bell,
   Activity,
   PanelLeft,
+  Building2,
+  ChevronsUpDown,
+  Moon,
+  Sun,
+  Maximize2,
+  Minimize2,
 } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Logo } from "@/components/ui/logo"
+import { Button } from "@/components/ui/button"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import ProfileDropdown from "@/components/shadcn-studio/blocks/dropdown-profile"
+import NotificationDropdown from "@/components/shadcn-studio/blocks/dropdown-notification"
+import LanguageDropdown from "@/components/shadcn-studio/blocks/dropdown-language"
 
 const nav = [
   { label: "Overview", icon: LayoutDashboard },
@@ -43,15 +59,61 @@ const stats = [
   { label: "Cost to date", value: "$182,940", delta: "+5.7% vs budget" },
 ]
 
+const buildings = [
+  "Toronto Distribution Center",
+  "Hamilton Manufacturing Plant",
+  "Mississauga Cold Storage",
+  "Ottawa Head Office",
+]
+
 /**
  * Inline preview of the full application shell — sidebar, top bar, and content
  * layout composed from registry primitives. Self-contained (no standalone
- * route): the persistent frame is structural markup styled with sidebar
- * tokens, while the top-bar menus are the real interactive block components.
+ * route): the persistent frame is structural markup styled with sidebar tokens,
+ * while the top-bar menus are the real interactive block components.
+ *
+ * Interactive bits: a building/location switcher, a dark-mode toggle (flips the
+ * real `.dark` class on <html>, as a consuming app would), an expand-to-full-
+ * screen control (Escape to exit), and the account menu docked in the sidebar
+ * footer. Language and notifications are wired as placeholders for future support.
  */
 export function ApplicationShellDemo() {
+  const [expanded, setExpanded] = React.useState(false)
+  const [dark, setDark] = React.useState(false)
+  const [building, setBuilding] = React.useState(buildings[0])
+
+  // Mirror the current theme so the toggle icon stays right even if the theme
+  // is changed elsewhere on the page.
+  React.useEffect(() => {
+    const root = document.documentElement
+    const sync = () => setDark(root.classList.contains("dark"))
+    sync()
+    const obs = new MutationObserver(sync)
+    obs.observe(root, { attributes: true, attributeFilter: ["class"] })
+    return () => obs.disconnect()
+  }, [])
+
+  // Escape collapses the maximized shell.
+  React.useEffect(() => {
+    if (!expanded) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setExpanded(false)
+    }
+    document.addEventListener("keydown", onKey)
+    return () => document.removeEventListener("keydown", onKey)
+  }, [expanded])
+
+  const toggleDark = () => document.documentElement.classList.toggle("dark")
+
   return (
-    <div className="relative flex h-[560px] w-full overflow-hidden rounded-xl border border-border bg-background text-sm">
+    <div
+      className={cn(
+        "flex overflow-hidden border border-border bg-background text-sm",
+        expanded
+          ? "fixed inset-0 z-50 rounded-none"
+          : "relative h-[560px] w-full rounded-xl"
+      )}
+    >
       {/* Sidebar */}
       <aside className="hidden w-56 shrink-0 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground md:flex">
         <div className="flex h-14 items-center gap-2 border-b border-sidebar-border px-4">
@@ -73,11 +135,35 @@ export function ApplicationShellDemo() {
             </button>
           ))}
         </nav>
-        <div className="border-t border-sidebar-border p-2">
+        {/* Footer: settings + the account menu, docked bottom-left */}
+        <div className="flex flex-col gap-0.5 border-t border-sidebar-border p-2">
           <button className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left font-medium text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent/50 hover:text-sidebar-foreground">
             <Settings className="size-4 shrink-0" />
             Settings
           </button>
+          <ProfileDropdown
+            align="start"
+            trigger={
+              <button className="flex w-full items-center gap-2.5 rounded-md p-1.5 text-left transition-colors hover:bg-sidebar-accent/50">
+                <Avatar size="sm">
+                  <AvatarImage
+                    src="https://cdn.shadcnstudio.com/ss-assets/avatar/avatar-1.png"
+                    alt="Priya Sharma"
+                  />
+                  <AvatarFallback>PS</AvatarFallback>
+                </Avatar>
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate text-xs font-medium text-sidebar-foreground">
+                    Priya Sharma
+                  </span>
+                  <span className="truncate text-[11px] text-sidebar-foreground/60">
+                    priya.sharma@edgecom.ai
+                  </span>
+                </div>
+                <ChevronsUpDown className="size-3.5 shrink-0 text-sidebar-foreground/60" />
+              </button>
+            }
+          />
         </div>
       </aside>
 
@@ -85,16 +171,48 @@ export function ApplicationShellDemo() {
       <div className="flex min-w-0 flex-1 flex-col">
         {/* Top bar */}
         <header className="flex h-14 shrink-0 items-center gap-3 border-b border-border px-4">
-          <Button variant="ghost" size="icon" className="md:hidden" aria-label="Toggle navigation">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="md:hidden"
+            aria-label="Toggle navigation"
+          >
             <PanelLeft className="size-4" />
           </Button>
-          <InputGroup className="max-w-xs">
+          <InputGroup className="hidden max-w-xs sm:flex">
             <InputGroupAddon>
               <Search />
             </InputGroupAddon>
             <InputGroupInput placeholder="Search sites, meters…" />
           </InputGroup>
-          <div className="ml-auto flex items-center gap-0.5">
+          <div className="ml-auto flex items-center gap-1">
+            {/* Building / location switcher — present on client-side screens */}
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <Button variant="outline" size="sm" className="max-w-[200px] gap-2">
+                    <Building2 className="size-4 shrink-0" />
+                    <span className="truncate">{building}</span>
+                    <ChevronsUpDown className="size-3.5 shrink-0 opacity-60" />
+                  </Button>
+                }
+              />
+              <DropdownMenuContent align="end" className="w-64">
+                <DropdownMenuRadioGroup
+                  value={building}
+                  onValueChange={(value) => setBuilding(value as string)}
+                >
+                  <DropdownMenuLabel>Switch building</DropdownMenuLabel>
+                  {buildings.map((b) => (
+                    <DropdownMenuRadioItem key={b} value={b}>
+                      {b}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            {/* Language & notifications — placeholders for future support */}
             <LanguageDropdown
               trigger={
                 <Button variant="ghost" size="icon" aria-label="Language">
@@ -104,32 +222,42 @@ export function ApplicationShellDemo() {
             />
             <NotificationDropdown
               trigger={
-                <Button variant="ghost" size="icon" className="relative" aria-label="Notifications">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="relative"
+                  aria-label="Notifications"
+                >
                   <Bell className="size-4" />
                   <span className="absolute right-1.5 top-1.5 block size-2 rounded-full bg-primary ring-2 ring-background" />
                 </Button>
               }
             />
-            <ActivityDialog
-              trigger={
-                <Button variant="ghost" size="icon" aria-label="Activity">
-                  <Activity className="size-4" />
-                </Button>
-              }
-            />
-            <ProfileDropdown
-              trigger={
-                <Button variant="ghost" size="icon" className="rounded-full" aria-label="Account">
-                  <Avatar size="sm">
-                    <AvatarImage
-                      src="https://cdn.shadcnstudio.com/ss-assets/avatar/avatar-1.png"
-                      alt="Priya Sharma"
-                    />
-                    <AvatarFallback>PS</AvatarFallback>
-                  </Avatar>
-                </Button>
-              }
-            />
+
+            {/* Dark-mode toggle (replaces the activity feed) */}
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={toggleDark}
+              aria-label="Toggle dark mode"
+              aria-pressed={dark}
+            >
+              {dark ? <Sun className="size-4" /> : <Moon className="size-4" />}
+            </Button>
+
+            {/* Expand the shell to full screen */}
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setExpanded((v) => !v)}
+              aria-label={expanded ? "Exit full screen" : "Expand to full screen"}
+            >
+              {expanded ? (
+                <Minimize2 className="size-4" />
+              ) : (
+                <Maximize2 className="size-4" />
+              )}
+            </Button>
           </div>
         </header>
 
@@ -140,7 +268,7 @@ export function ApplicationShellDemo() {
               Portfolio overview
             </h2>
             <p className="text-xs text-muted-foreground">
-              Toronto Distribution Center · 14 metered sites
+              {building} · 14 metered sites
             </p>
           </div>
           <div className="mt-4 grid gap-3 sm:grid-cols-3">

--- a/src/components/shadcn-studio/select/select-32.tsx
+++ b/src/components/shadcn-studio/select/select-32.tsx
@@ -1,0 +1,104 @@
+import { Label } from '@/components/ui/label'
+import type { Option } from '@/components/ui/multi-select'
+import MultipleSelector from '@/components/ui/multi-select'
+
+const categories: Option[] = [
+  {
+    value: 'clothing',
+    label: 'Clothing'
+  },
+  {
+    value: 'footwear',
+    label: 'Footwear'
+  },
+  {
+    value: 'accessories',
+    label: 'Accessories'
+  },
+  {
+    value: 'jewelry',
+    label: 'Jewelry',
+    disable: true
+  },
+  {
+    value: 'outerwear',
+    label: 'Outerwear'
+  },
+  {
+    value: 'fragrance',
+    label: 'Fragrance'
+  },
+  {
+    value: 'makeup',
+    label: 'Makeup'
+  },
+  {
+    value: 'skincare',
+    label: 'Skincare'
+  },
+  {
+    value: 'furniture',
+    label: 'Furniture'
+  },
+  {
+    value: 'lighting',
+    label: 'Lighting'
+  },
+  {
+    value: 'kitchenware',
+    label: 'Kitchenware',
+    disable: true
+  },
+  {
+    value: 'computers',
+    label: 'Computers'
+  },
+  {
+    value: 'audio',
+    label: 'Audio'
+  },
+  {
+    value: 'wearables',
+    label: 'Wearables'
+  },
+  {
+    value: 'supplements',
+    label: 'Supplements'
+  },
+  {
+    value: 'sportswear',
+    label: 'Sportswear'
+  }
+]
+
+const MultipleSelectDemo = () => {
+  return (
+    <div className='w-full max-w-xs space-y-2'>
+      <Label>Multiselect</Label>
+      <MultipleSelector
+        commandProps={{
+          label: 'Select categories'
+        }}
+        value={categories.slice(0, 2)}
+        defaultOptions={categories}
+        placeholder='Select categories'
+        hideClearAllButton
+        hidePlaceholderWhenSelected
+        emptyIndicator={<p className='text-center text-sm'>No results found</p>}
+        className='w-full'
+      />
+      <p className='text-muted-foreground text-xs' role='region' aria-live='polite'>
+        Inspired by{' '}
+        <a
+          href='https://shadcnui-expansions.typeart.cc/docs/multiple-selector'
+          className='hover:text-primary underline'
+          target='_blank'
+        >
+          shadcn/ui expressions
+        </a>
+      </p>
+    </div>
+  )
+}
+
+export default MultipleSelectDemo


### PR DESCRIPTION
- **AGENTS.md guardrails** — updated guidelines and guardrails (import from the
  registry / don't recreate → stop-and-ask if nothing fits; responsiveness &
  scaling; dark mode & theming) so AI coding agents build with the design system
  correctly.
- **Custom-domain deploy** — the docs site now serves at design.edgecom.ai (root
  path). Made the Pages build root-relative (dropped PAGES_BASE_PATH=/design-system),
  added public/CNAME, and updated next.config.ts + the AGENTS.md docs-architecture
  section to match.
- **Application shell demo** — added a full-screen expand toggle (Esc to exit), a
  building/location switcher (updates the header subtitle live), moved the account
  menu into the sidebar footer, kept Language/Notifications as future placeholders,
  and replaced the activity feed with a dark-mode toggle.
- **Select demo** — added a multiselect variant from shadcn-studio and registered it
  in the Select section.

Verified: `tsc` strict clean, `pnpm lint` 0 errors, `pnpm build` (static export) passes; interactive changes checked in the browser in light + dark. `.claude/launch.json` excluded (machine-specific).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Select example demonstrating multiple selections with preset values.
  - Enhanced the application shell demo with building switching, dark mode, expandable layout, keyboard minimization, and updated settings/profile controls.

- **Improvements**
  - Documentation site now serves from the custom domain at the root path.
  - Added improved guidance for responsive, accessible, themed UI development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->