### PR TITLE
Fix/select styled and ux guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,18 @@ These apply whenever you build UI with these components (in this repo or a consu
 - **Mechanics.** Dark mode is the `.dark` class on the `<html>` root; portaled content (dropdown, popover, tooltip, toast) inherits it — don't build light-only components. Adding or adjusting a color means editing `globals.css` (both `:root` **and** `.dark`), not the call site.
 - **Always test both light and dark** before shipping anything visible.
 
+### Interaction patterns & feedback
+
+- **Buttons need real hover (and focus) states.** Use the design-system `button` — its variants ship hover + focus-ring styling for free. If you build any custom clickable control, it must have a visible `hover:` state and a focus ring (`--ring`); never ship a flat, stateless button.
+- **Pick the right overlay — dialog vs. sheet.** Match the surface to the amount of input:
+  - **Short create actions (1–4 fields) → modal `dialog`** — quick, centered, focused.
+  - **Longer edit/update actions (many fields) → right-side `sheet`** — room for dense forms without a cramped modal.
+  - Both are Base UI primitives: trigger via the `render` prop, and portaled content inherits dark mode.
+- **Always surface validation / error states — never fail silently.** If a required field is empty when the user tries to proceed, show inline error text that names what's missing (e.g. "Site name is required") next to the field — not just a generic toast or a blocked button with no explanation.
+  - Wire it through the `field` component's `FieldError` slot and set `aria-invalid` on the input; the `input` / `select` primitives already render the destructive border + ring from `aria-invalid`.
+  - Use the destructive token for the message (the `-emphasis` variant when it's text — see *Design tokens & accessibility*), and pair color with text/icon — never color alone.
+  - This complements the loading / empty / error-state guardrail (`skeleton` / `spinner` / `empty`).
+
 ### Other guardrails
 
 - **Accessibility.** Rely on Base UI primitives for interactive widgets — don't reimplement them (you lose keyboard/ARIA support). Keep a visible focus ring via `--ring` (never `outline: none` with no replacement), label form fields, and give images alt text.
@@ -156,6 +168,9 @@ There is **no test framework** in this repo. The quality gates are:
 ## Do-nots
 
 - Don't hand-write a component the registry already provides — import it; if none fits, stop and ask.
+- Don't ship a button or interactive control without a visible hover + focus state.
+- Don't cram a long, many-field form into a centered modal — use a right sheet; keep dialogs for short (1–4 field) create actions.
+- Don't block a user on validation without inline, specific error text (name the missing field) and `aria-invalid`.
 - Don't hardcode colors or ship light-only UI — every color is a light+dark token; test both.
 - Don't pin sizes to px — use the rem type / spacing / radius scales.
 - Don't hardcode hex — use semantic tokens.

--- a/src/app/sections.tsx
+++ b/src/app/sections.tsx
@@ -20,7 +20,7 @@ import { cn } from "@/lib/utils";
 import { ComponentPreview, InstallCommand } from "@/components/docs/component-preview";
 import { Toc } from "@/components/docs/toc";
 import { SeparatorDemo } from "@/components/demo/separator-demo";
-import { ApplicationShellDemo } from "@/components/demo/application-shell-demo";
+import { ApplicationShellPreview } from "@/components/demo/application-shell-preview";
 import { AvatarBasicDemo, AvatarGroupDemo } from "@/components/demo/avatar-demo";
 import { ScrollAreaDemo } from "@/components/demo/scroll-area-demo";
 import { SheetDemo } from "@/components/demo/sheet-demo";
@@ -3420,7 +3420,7 @@ export const sections: Section[] = [
         name: "Dashboard shell",
         description:
           "Sidebar navigation, a top bar with search and account menus, and a scrollable content area — composed from registry primitives.",
-        preview: <ApplicationShellDemo />,
+        preview: <ApplicationShellPreview />,
         source: dm("application-shell-demo"),
       },
     ],

--- a/src/app/sections.tsx
+++ b/src/app/sections.tsx
@@ -60,8 +60,6 @@ import RadioGroupDemo from "@/components/shadcn-studio/radio-group/radio-group-0
 import RadioGroupHorizontalDemo from "@/components/shadcn-studio/radio-group/radio-group-02";
 import RadioGroupCardRadioDemo from "@/components/shadcn-studio/radio-group/radio-group-11";
 import RadioGroupCardVerticalRadioDemo from "@/components/shadcn-studio/radio-group/radio-group-13";
-import NativeSelectDemo from "@/components/shadcn-studio/select/select-01";
-import NativeSelectPlaceholderDemo from "@/components/shadcn-studio/select/select-02";
 import NativeSelectRequiredDemo from "@/components/shadcn-studio/select/select-06";
 import SelectWithOptionsGroupsDemo from "@/components/shadcn-studio/select/select-22";
 import MultipleSelectWithPlaceholderDemo from "@/components/shadcn-studio/select/select-33";
@@ -153,6 +151,8 @@ import { ToggleFormattingDemo } from "@/components/demo/toggle-formatting-demo";
 import { SliderBasicDemo } from "@/components/demo/slider-basic-demo";
 import { ProgressLinearDemo } from "@/components/demo/progress-linear-demo";
 import { SelectSitesDemo } from "@/components/demo/select-sites-demo";
+import { SelectCommodityDemo } from "@/components/demo/select-commodity-demo";
+import { SelectCommodityPlaceholderDemo } from "@/components/demo/select-commodity-placeholder-demo";
 import { TextareaNoteDemo } from "@/components/demo/textarea-note-demo";
 import { DatePickerDemo } from "@/components/demo/date-picker-demo";
 import DatePickerRangeDemo from "@/components/shadcn-studio/date-picker/date-picker-02";
@@ -2390,18 +2390,18 @@ export const sections: Section[] = [
         source: dm("select-sites-demo"),
       },
       {
-        id: "select-native",
-        name: "Native select",
-        description: "The browser's native select element, styled to match.",
-        preview: <NativeSelectDemo />,
-        source: ss("select/select-01"),
+        id: "select-single",
+        name: "Single value",
+        description: "A single-value select styled to match the design system.",
+        preview: <SelectCommodityDemo />,
+        source: dm("select-commodity-demo"),
       },
       {
-        id: "select-native-placeholder",
-        name: "Native with placeholder",
-        description: "A native select with a non-selectable placeholder.",
-        preview: <NativeSelectPlaceholderDemo />,
-        source: ss("select/select-02"),
+        id: "select-placeholder",
+        name: "With placeholder",
+        description: "A select showing a placeholder until a value is chosen.",
+        preview: <SelectCommodityPlaceholderDemo />,
+        source: dm("select-commodity-placeholder-demo"),
       },
       {
         id: "select-native-required",

--- a/src/components/demo/application-shell-demo.tsx
+++ b/src/components/demo/application-shell-demo.tsx
@@ -17,11 +17,8 @@ import {
   ChevronsUpDown,
   Moon,
   Sun,
-  Maximize2,
-  Minimize2,
 } from "lucide-react"
 
-import { cn } from "@/lib/utils"
 import { Logo } from "@/components/ui/logo"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -67,18 +64,17 @@ const buildings = [
 ]
 
 /**
- * Inline preview of the full application shell — sidebar, top bar, and content
- * layout composed from registry primitives. Self-contained (no standalone
- * route): the persistent frame is structural markup styled with sidebar tokens,
+ * The full application shell — sidebar, top bar, and scrollable content, composed
+ * from registry primitives and sized to fill its container. Self-contained (no
+ * standalone route): the frame is structural markup styled with sidebar tokens,
  * while the top-bar menus are the real interactive block components.
  *
  * Interactive bits: a building/location switcher, a dark-mode toggle (flips the
- * real `.dark` class on <html>, as a consuming app would), an expand-to-full-
- * screen control (Escape to exit), and the account menu docked in the sidebar
- * footer. Language and notifications are wired as placeholders for future support.
+ * real `.dark` class on <html>, as a consuming app would), and the account menu
+ * docked in the sidebar footer. Language and notifications are wired as
+ * placeholders for future support.
  */
 export function ApplicationShellDemo() {
-  const [expanded, setExpanded] = React.useState(false)
   const [dark, setDark] = React.useState(false)
   const [building, setBuilding] = React.useState(buildings[0])
 
@@ -93,27 +89,10 @@ export function ApplicationShellDemo() {
     return () => obs.disconnect()
   }, [])
 
-  // Escape collapses the maximized shell.
-  React.useEffect(() => {
-    if (!expanded) return
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false)
-    }
-    document.addEventListener("keydown", onKey)
-    return () => document.removeEventListener("keydown", onKey)
-  }, [expanded])
-
   const toggleDark = () => document.documentElement.classList.toggle("dark")
 
   return (
-    <div
-      className={cn(
-        "flex overflow-hidden border border-border bg-background text-sm",
-        expanded
-          ? "fixed inset-0 z-50 rounded-none"
-          : "relative h-[560px] w-full rounded-xl"
-      )}
-    >
+    <div className="flex size-full overflow-hidden bg-background text-sm">
       {/* Sidebar */}
       <aside className="hidden w-56 shrink-0 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground md:flex">
         <div className="flex h-14 items-center gap-2 border-b border-sidebar-border px-4">
@@ -234,7 +213,7 @@ export function ApplicationShellDemo() {
               }
             />
 
-            {/* Dark-mode toggle (replaces the activity feed) */}
+            {/* Dark-mode toggle */}
             <Button
               variant="ghost"
               size="icon"
@@ -243,20 +222,6 @@ export function ApplicationShellDemo() {
               aria-pressed={dark}
             >
               {dark ? <Sun className="size-4" /> : <Moon className="size-4" />}
-            </Button>
-
-            {/* Expand the shell to full screen */}
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setExpanded((v) => !v)}
-              aria-label={expanded ? "Exit full screen" : "Expand to full screen"}
-            >
-              {expanded ? (
-                <Minimize2 className="size-4" />
-              ) : (
-                <Maximize2 className="size-4" />
-              )}
             </Button>
           </div>
         </header>

--- a/src/components/demo/application-shell-preview.tsx
+++ b/src/components/demo/application-shell-preview.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import * as React from "react"
+import { Maximize2, Minimize2 } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { ApplicationShellDemo } from "./application-shell-demo"
+
+/**
+ * Docs-only wrapper: frames the application shell in a card and adds an
+ * expand-to-full-screen control (Escape to exit) in a slim top toolbar so the
+ * full layout is easy to inspect inside the cramped preview area. This
+ * affordance is demo scaffolding — the shell a consumer copies is
+ * `application-shell-demo.tsx`, which fills its container and has no full-screen
+ * button. (The control lives in this toolbar rather than overlaying the shell's
+ * top-right corner, which is already occupied by the shell's header controls.)
+ */
+export function ApplicationShellPreview() {
+  const [expanded, setExpanded] = React.useState(false)
+
+  React.useEffect(() => {
+    if (!expanded) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setExpanded(false)
+    }
+    document.addEventListener("keydown", onKey)
+    return () => document.removeEventListener("keydown", onKey)
+  }, [expanded])
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col overflow-hidden border border-border bg-background",
+        expanded ? "fixed inset-0 z-50" : "h-[560px] w-full rounded-xl"
+      )}
+    >
+      <div className="flex justify-end border-b border-border bg-muted/30 px-2 py-1.5">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => setExpanded((v) => !v)}
+          aria-label={expanded ? "Exit full screen" : "Expand to full screen"}
+        >
+          {expanded ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1">
+        <ApplicationShellDemo />
+      </div>
+    </div>
+  )
+}

--- a/src/components/demo/select-commodity-demo.tsx
+++ b/src/components/demo/select-commodity-demo.tsx
@@ -1,0 +1,30 @@
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select"
+
+const commodities = [
+  { label: "Electricity", value: "electricity" },
+  { label: "Water", value: "water" },
+  { label: "Gas", value: "gas" },
+]
+
+export function SelectCommodityDemo() {
+  return (
+    <Select items={commodities} defaultValue="electricity">
+      <SelectTrigger className="w-56">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {commodities.map((c) => (
+          <SelectItem key={c.value} value={c.value}>
+            {c.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/src/components/demo/select-commodity-placeholder-demo.tsx
+++ b/src/components/demo/select-commodity-placeholder-demo.tsx
@@ -1,0 +1,30 @@
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select"
+
+const commodities = [
+  { label: "Electricity", value: "electricity" },
+  { label: "Water", value: "water" },
+  { label: "Gas", value: "gas" },
+]
+
+export function SelectCommodityPlaceholderDemo() {
+  return (
+    <Select items={commodities}>
+      <SelectTrigger className="w-56">
+        <SelectValue placeholder="Please select a commodity" />
+      </SelectTrigger>
+      <SelectContent>
+        {commodities.map((c) => (
+          <SelectItem key={c.value} value={c.value}>
+            {c.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}


### PR DESCRIPTION
## What & why

- **Select bugfix** — the "Native select" and "Native with placeholder" variants used a raw HTML `<select>` (OS dropdown), inconsistent with the styled grouped-sites `Select`. Replaced them with house-style demos on the custom `Select` primitive — **"Single value"** and **"With placeholder"** — passing an `items` map so the trigger shows the option *label* ("Electricity") rather than the raw value. shadcn-studio vendor files left untouched; **"Native required"** stays as the `native-select` showcase.
- **AGENTS.md guardrails** — new "Interaction patterns & feedback" subsection: buttons need hover/focus states; `dialog` for short (1–4 field) create actions vs. right `sheet` for long edit forms; always surface inline validation/error states (`FieldError` + `aria-invalid`). Mirrored in the Do-nots list.

## Verification
- `tsc` strict clean; no console errors.
- Select verified in the browser (light + dark): single value shows "Electricity", placeholder shows muted "Please select a commodity", dropdown opens as the styled popover.
- AGENTS.md is docs-only; references real primitives (`button`, `dialog`, `sheet`, `field`/`FieldError`, `input`/`select`).

## Reviewer notes
- Registry (`registry.json`) unchanged — these are demos, not registry items.
- `.claude/launch.json` intentionally excluded (machine-specific pnpm path).
- Follow-ups discussed, not in this PR: add a **"Sizes"** demo to the Select section (the `size="sm"` capability already exists but isn't shown), and optionally give `Input` a matching `sm` height for compact-row alignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a full-screen preview option for the application shell, including Escape-key support to exit.
  - Added single-value and placeholder select examples using commodity options.

- **Updates**
  - Refreshed the component documentation examples and available Select variants.
  - Removed the full-screen control from the embedded application shell demo.

- **Documentation**
  - Clarified interaction, focus, dialog/sheet, and inline validation accessibility guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->